### PR TITLE
Adding IPv6 support by querying RR type field

### DIFF
--- a/src/ws/ddns/update.py
+++ b/src/ws/ddns/update.py
@@ -12,7 +12,6 @@ except ImportError:  # soft dependency
     pyotp = None
 
 
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 log = logging.getLogger(__name__)
 
 def serialize_xml(xml):
@@ -79,7 +78,6 @@ class DNS(object):
 
         ip_obj = ipaddress.ip_address(ip)
         rtype = 'A' if isinstance(ip_obj, ipaddress.IPv4Address) else 'AAAA'
-        log.debug('RTYPE: %s', rtype)
 
         current = zone.xpath('//rr[name = "%s" and type = "%s"]' % (host, rtype))
         if not current:


### PR DESCRIPTION
Hi @wosc , thanks again for maintaining this!

If my PR seems worthwhile, please consider merging into main? Let me know if you have any questions / changes in mind.

### Description:
Adding RR type filter to the XPath expression allows distinguishing between A and AAAA type entries.

The provided IP Address is parsed into an IP address object by calling `ipaddress.ip_address(ip)` (python>=3.3) and checked for IPv4 vs IPv6 types. The XPath filter is built accordingly so that only matching hostname entries are returned.

No further changes needed as far as I can see. If an ipv6 comes in, DNS object looks for AAAA entries, if ipv4 is to be updated, A record-type entries are returned.

I stumbled upon this because of a dyndns client coming from a pure ipv6 address. As long as both A and AAAA records exist in the zone, this PR will update the correct one depending on query param ip type.

### Note / Limitation:

- The implications of having both ipv4 and ipv6 entries for the same hostname in your zone need to be evaluated individually.
- If you only have on A **OR** an AAAA resource record for the domain, this PR will do nothing.

One thing that I haven't looked into yet: If multiple entries exist and are returned, only the first is used subsequently as per current code. If there are more than one A or AAAA entries for a hostname but with different priority values, I'm not sure if the gateway returns them in priority-order and lxml will parse them accordingly. A fix could include parsing for <pref></pref> and choosing lowest available. Since it's rather unlikely in a home-dyndns env to have multiple A(AAA) records per domain name, this shouldn't weigh in much. Could be relevant in other settings.

Thanks.